### PR TITLE
Fixes Issue 45 - Adds React-Navigation for Stack Support

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,7 +4,7 @@ import {
   createBottomTabNavigator,
 } from 'react-navigation';
 import { Ionicons } from '@expo/vector-icons';
-
+import PropTypes from 'prop-types';
 import { TwMapView } from './components/TwMapView';
 import { TwListView } from './components/TwListView';
 import { getInitialData } from './utils/api';
@@ -54,6 +54,40 @@ const MapStack = createStackNavigator({
   Map: { screen: TwMapView },
 });
 
+/**
+ * @function
+ * renders mapIcon
+*/
+function MapIcon({ tintColor }) {
+  return <Ionicons name="md-map" size={25} style={{ color: tintColor }} />;
+}
+
+MapIcon.propTypes = {
+  tintColor: PropTypes.string.isRequired,
+};
+
+/**
+ * @function
+ * renders listIcon
+*/
+function ListIcon({ tintColor }) {
+  return <Ionicons name="md-alert" size={25} style={{ color: tintColor }} />;
+}
+
+ListIcon.propTypes = {
+  tintColor: PropTypes.string.isRequired,
+};
+
+ListStack.navigationOptions = {
+  tabBarLabel: 'List',
+  tabBarIcon: ListIcon,
+};
+
+MapStack.navigationOptions = {
+  tabBarLabel: 'Map',
+  tabBarIcon: MapIcon,
+};
+
 const RootNavigation = createBottomTabNavigator(
   {
     ListView: {
@@ -64,25 +98,6 @@ const RootNavigation = createBottomTabNavigator(
     },
   },
   {
-    navigationOptions: ({ navigation }) => ({
-      tabBarIcon: ({ tintColor }) => {
-        const { routeName } = navigation.state;
-        let iconName;
-        switch (routeName) {
-        case 'ListView':
-          iconName = 'alert';
-          break;
-        case 'MapScreen':
-          iconName = 'map';
-          break;
-        default:
-          iconName = 'questions';
-          break;
-        }
-        // TODO: Make this platform specific
-        return <Ionicons name={`md-${iconName}`} size={25} style={{ color: tintColor }} />;
-      },
-    }),
     tabBarOptions: {
       activeTintColor: 'tomato',
       inactiveColor: 'gray',

--- a/App.js
+++ b/App.js
@@ -1,37 +1,23 @@
 import React from 'react';
-import { StyleSheet, Dimensions } from 'react-native';
-import { TabViewAnimated, TabBar } from 'react-native-tab-view';
+import {
+  createStackNavigator,
+  createBottomTabNavigator,
+} from 'react-navigation';
+import { Ionicons } from '@expo/vector-icons';
+
 import { TwMapView } from './components/TwMapView';
 import { TwListView } from './components/TwListView';
 import { getInitialData } from './utils/api';
 
-const initialLayout = {
-  height: 0,
-  width: Dimensions.get('window').width,
-};
-
-const styles = StyleSheet.create({ // eslint-disable-line no-unused-vars
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});
 
 /**
 * @class App
 * Main View of the application showing tabs for the list and mapview
 */
-export default class App extends React.Component {
+class App extends React.Component {
   state = {
-    index: 0, // eslint-disable-line react/no-unused-state
-    routes: [ // eslint-disable-line react/no-unused-state
-      { key: 'list', title: 'List' },
-      { key: 'map', title: 'Map' },
-    ],
-    data: [], // eslint-disable-line react/no-unused-state
-  };
+    data: [],
+  }
 
   /**
    * @function componentDidMount
@@ -45,34 +31,63 @@ export default class App extends React.Component {
     });
   }
 
-  /* eslint-disable react/no-unused-state */
-  _handleIndexChange = index => this.setState({ index });
-  /* eslint-enable react/no-unused-state */
-
-  _renderFooter = props => <TabBar {...props} />;
-
-  _renderScene = ({ route }) => {
-    switch (route.key) {
-    case 'map':
-      return <TwMapView data={this.state.data} />;
-    default:
-      return <TwListView data={this.state.data} />;
-    }
-  }
-
   /**
   * @function render
   * setting up the view
   */
   render() {
+    const { data } = this.state;
+    const screenProps = {
+      data,
+    };
     return (
-      <TabViewAnimated
-        navigationState={this.state}
-        renderScene={this._renderScene}
-        renderFooter={this._renderFooter}
-        onIndexChange={this._handleIndexChange}
-        initialLayout={initialLayout}
-      />
+      <RootNavigation screenProps={screenProps} />
     );
   }
 }
+
+const ListStack = createStackNavigator({
+  List: { screen: TwListView },
+});
+
+const MapStack = createStackNavigator({
+  Map: { screen: TwMapView },
+});
+
+const RootNavigation = createBottomTabNavigator(
+  {
+    ListView: {
+      screen: ListStack,
+    },
+    MapScreen: {
+      screen: MapStack,
+    },
+  },
+  {
+    navigationOptions: ({ navigation }) => ({
+      tabBarIcon: ({ tintColor }) => {
+        const { routeName } = navigation.state;
+        let iconName;
+        switch (routeName) {
+        case 'ListView':
+          iconName = 'alert';
+          break;
+        case 'MapScreen':
+          iconName = 'map';
+          break;
+        default:
+          iconName = 'questions';
+          break;
+        }
+        // TODO: Make this platform specific
+        return <Ionicons name={`md-${iconName}`} size={25} style={{ color: tintColor }} />;
+      },
+    }),
+    tabBarOptions: {
+      activeTintColor: 'tomato',
+      inactiveColor: 'gray',
+    },
+  },
+);
+
+export default App;

--- a/components/TwListView.js
+++ b/components/TwListView.js
@@ -1,5 +1,7 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { StyleSheet, ScrollView, Text, TextInput, View } from 'react-native';
+
 /*
  * StyleSheet
  * textInput for search bar style
@@ -51,6 +53,7 @@ const styles = StyleSheet.create({
   },
 
 });
+
 // disabled for now, at least until we figure out if this
 // will have state or not
 /* eslint-disable react/prefer-stateless-function */
@@ -61,11 +64,15 @@ const styles = StyleSheet.create({
 * the View has a bar
 */
 export class TwListView extends React.Component {
+  static navigationOptions = () => ({
+    header: null,
+  });
+
   /**
   * @function render
   */
   render() {
-    const props = this.props;
+    const props = this.props.screenProps;
     return (
       <ScrollView style={styles.container}>
         <TextInput
@@ -88,3 +95,31 @@ export class TwListView extends React.Component {
   }
 }
 /* eslint-enable react/prefer-stateless-function */
+
+TwListView.propTypes = {
+  screenProps: PropTypes.shape({
+    data: PropTypes.arrayOf(PropTypes.shape({
+      OBJECTID: PropTypes.number,
+      WORKTYPE: PropTypes.string,
+      TITLE: PropTypes.string,
+      STARTDATE: PropTypes.number,
+      ENDDATE: PropTypes.number,
+      CONTACTDETAILS: PropTypes.string,
+      AFFECTEDPREMISES: PropTypes.string,
+      TRAFFICIMPLICATIONS: PropTypes.string,
+      DESCRIPTION: PropTypes.string,
+      STATUS: PropTypes.string,
+      GLOBALID: PropTypes.string,
+      APPROVALSTATUS: PropTypes.string,
+      LOCATION: PropTypes.string,
+      PRIORITY: PropTypes.string,
+      COUNTY: PropTypes.string,
+      REFERENCENUM: PropTypes.string,
+      PROJECTNUMBER: PropTypes.string,
+      PROJECT: PropTypes.string,
+      LAT: PropTypes.number,
+      LONG: PropTypes.number,
+      NOTICETYPE: PropTypes.arrayOf(PropTypes.string),
+    })).isRequired,
+  }).isRequired,
+};

--- a/components/TwMapView.js
+++ b/components/TwMapView.js
@@ -17,6 +17,10 @@ const styles = StyleSheet.create({
 * display of data on a map
 */
 export class TwMapView extends React.Component {
+  static navigationOptions = () => ({
+    header: null,
+  });
+
   state = {
     region: {
       latitude: 53.350140,
@@ -55,7 +59,7 @@ export class TwMapView extends React.Component {
   */
   _findLocalMarkers() {
     const regionInfo = this.state.region;
-    const allNotices = this.props.data;
+    const allNotices = this.props.screenProps.data;
     const localNotices = [];
     const latDelta = regionInfo.latitudeDelta;
     const lngDelta = regionInfo.longitudeDelta;
@@ -113,27 +117,29 @@ export class TwMapView extends React.Component {
 }
 
 TwMapView.propTypes = {
-  data: PropTypes.arrayOf(PropTypes.shape({
-    OBJECTID: PropTypes.number,
-    WORKTYPE: PropTypes.string,
-    TITLE: PropTypes.string,
-    STARTDATE: PropTypes.number,
-    ENDDATE: PropTypes.number,
-    CONTACTDETAILS: PropTypes.string,
-    AFFECTEDPREMISES: PropTypes.string,
-    TRAFFICIMPLICATIONS: PropTypes.string,
-    DESCRIPTION: PropTypes.string,
-    STATUS: PropTypes.string,
-    GLOBALID: PropTypes.string,
-    APPROVALSTATUS: PropTypes.string,
-    LOCATION: PropTypes.string,
-    PRIORITY: PropTypes.string,
-    COUNTY: PropTypes.string,
-    REFERENCENUM: PropTypes.string,
-    PROJECTNUMBER: PropTypes.string,
-    PROJECT: PropTypes.string,
-    LAT: PropTypes.number,
-    LONG: PropTypes.number,
-    NOTICETYPE: PropTypes.arrayOf(PropTypes.string),
-  })).isRequired,
+  screenProps: PropTypes.shape({
+    data: PropTypes.arrayOf(PropTypes.shape({
+      OBJECTID: PropTypes.number,
+      WORKTYPE: PropTypes.string,
+      TITLE: PropTypes.string,
+      STARTDATE: PropTypes.number,
+      ENDDATE: PropTypes.number,
+      CONTACTDETAILS: PropTypes.string,
+      AFFECTEDPREMISES: PropTypes.string,
+      TRAFFICIMPLICATIONS: PropTypes.string,
+      DESCRIPTION: PropTypes.string,
+      STATUS: PropTypes.string,
+      GLOBALID: PropTypes.string,
+      APPROVALSTATUS: PropTypes.string,
+      LOCATION: PropTypes.string,
+      PRIORITY: PropTypes.string,
+      COUNTY: PropTypes.string,
+      REFERENCENUM: PropTypes.string,
+      PROJECTNUMBER: PropTypes.string,
+      PROJECT: PropTypes.string,
+      LAT: PropTypes.number,
+      LONG: PropTypes.number,
+      NOTICETYPE: PropTypes.arrayOf(PropTypes.string),
+    })).isRequired,
+  }).isRequired,
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "jest-expo": "^27.0.1",
     "jsdoc": "^3.5.5",
     "prop-types": "^15.6.1",
-    "react-test-renderer": "^16.3.2"
+    "react-test-renderer": "16.3.0"
   },
   "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "preset": "jest-expo"
   },
   "dependencies": {
+    "@expo/vector-icons": "^6.3.1",
     "expo": "^26.0.0",
     "npm": "^5.8.0",
     "prop-types": "^15.6.1",
@@ -47,6 +48,7 @@
     "react-native-scripts": "^1.14.0",
     "react-native-searchbar": "^1.14.0",
     "react-native-tab-view": "^0.0.77",
-    "react-native-vector-icons": "^4.6.0"
+    "react-native-vector-icons": "^4.6.0",
+    "react-navigation": "^2.2.5"
   }
 }


### PR DESCRIPTION
This commit changes how we create our tab navigation to be react-navigation which is the official navigation package and also includes support for stack navigation which we'll use to stack item screens on top of the map & list view as well as create several screens in the settings component. 

Also upgrades from react 16.3.0 to 16.3.1 

fixes #45 